### PR TITLE
Update to the latest 2023.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 pluginName=logstash-intellij-plugin
 version=1.0-SNAPSHOT
 platformType = IC
-platformVersion = 2023.2
+platformVersion = 2023.3
 javaVersion = 17


### PR DESCRIPTION
Works with 2023.3 (tested locally).

However, this method of regularly updating `platformVersion` for every minor update does not seem very sustainable. I looked at recent plugins, and none of them seem to specify this key anymore... Happy to look into this over the Holidays (beyond this PR, of course)